### PR TITLE
Updated the config.sh file

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -38,5 +38,5 @@ declare DISTRO_VERSION=$(lsb_release -sr)
 # Default: build params
 DEFAULT_CONFIGURE_PARAMS+="--prefix=${NGINX_PATH} --sbin-path=sbin/nginx --conf-path=nginx.conf --pid-path=logs/nginx.pid --user=www-data "
 DEFAULT_CONFIGURE_PARAMS+="--with-pcre=../pcre --with-zlib=../zlib "
-DEFAULT_CONFIGURE_PARAMS+="--with-ipv6 --with-http_realip_module  --with-http_gzip_static_module --with-stream "
+DEFAULT_CONFIGURE_PARAMS+="--with-http_realip_module  --with-http_gzip_static_module --with-stream "
 

--- a/config.sh
+++ b/config.sh
@@ -39,4 +39,10 @@ declare DISTRO_VERSION=$(lsb_release -sr)
 DEFAULT_CONFIGURE_PARAMS+="--prefix=${NGINX_PATH} --sbin-path=sbin/nginx --conf-path=nginx.conf --pid-path=logs/nginx.pid --user=www-data "
 DEFAULT_CONFIGURE_PARAMS+="--with-pcre=../pcre --with-zlib=../zlib "
 DEFAULT_CONFIGURE_PARAMS+="--with-http_realip_module  --with-http_gzip_static_module --with-stream "
+DEFAULT_CONFIGURE_PARAMS+="--with-stream_ssl_preread_module --with-compat "
+DEFAULT_CONFIGURE_PARAMS+="--with-file-aio --with-threads --with-http_addition_module --with-http_auth_request_module "
+DEFAULT_CONFIGURE_PARAMS+="--with-http_dav_module --with-http_flv_module --with-http_mp4_module --with-http_random_index_module "
+DEFAULT_CONFIGURE_PARAMS+="--with-http_secure_link_module --with-http_slice_module --with-http_ssl_module --with-http_stub_status_module "
+DEFAULT_CONFIGURE_PARAMS+="--with-http_sub_module --with-http_v2_module --with-mail --with-mail_ssl_module "
+DEFAULT_CONFIGURE_PARAMS+="--with-stream_realip_module --with-stream_ssl_module "
 

--- a/config.sh
+++ b/config.sh
@@ -19,7 +19,7 @@ declare NGINX_SERVER_PORT="80" #
 declare -A CACHE="${ROOT}cache/"
 declare -A BUILD="${ROOT}build/" 
 
-declare -A VERSION=(['luajit']='2.0.4' ['nginx']='1.11.5' ['pcre']='8.39' ['zlib']='1.2.8' ['openssl']='1.0.2f')
+declare -A VERSION=(['luajit']='2.0.4' ['nginx']='1.11.8' ['pcre']='8.40' ['zlib']='1.2.11' ['openssl']='1.1.0c')
 # ./configure default settings
 #declare -A DEFAULT_CONFIGURE_PARAMS="--with-debug "
 declare -A DEFAULT_CONFIGURE_PARAMS=" "


### PR DESCRIPTION
The first commit updates the version numbers for the downloads.  The ZLIB version number is required at a minimum or the script fails.

The second commit removes the ipv6 flag which is deprecated in the new version of nginx.

The last commit adds all the additional flags for nginx.  I don't know if there was a reason not to include them or if they are actually included somewhere else, but I already had the list compiled so I added them in.